### PR TITLE
feat: Environment variable support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": true,
     "editor.rulers": [80],
-    "markdown-preview-github-styles.colorTheme": "light"
+    "markdown-preview-github-styles.colorTheme": "light",
+    "python.formatting.provider": "black"
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,64 @@ urlpatterns = [
 > For more information, refer to the Jinja
 > [documentation](https://jinja.palletsprojects.com/en/3.0.x/api/).
 
+## Environment variables
+
+Several settings or behaviours implemented by this library can be controlled via
+environment variables.  This is done via the
+[django-environ](https://django-environ.readthedocs.io/en/latest/) library.
+(Refer to their documentation on how to format special data types like lists)
+If your project root has a `.env` file, those values will be used.
+
+If you want to use environment variables in your project's configuration, you
+can simply reference django-environ directly as it will automatically be
+installed.  For example:
+
+```python
+import environ
+
+env = environ.Env(DEBUG=(bool, False))
+environ.Env.read_env()
+
+DEBUG = env('DEBUG')
+
+```
+
+This library also provides a utility that automatically declares a module level
+global while checking the environment.  It is particularly useful when declaring
+django settings.
+
+```python
+from .utils import global_from_env
+
+global_from_env(
+    SESSION_COOKIE_AGE=(int, 1200),
+)
+```
+
+The example above creates the module level global `SESSION_COOKIE_AGE` with a
+default value of 1200, unless there is an environment variable (or **.env** file
+entry) `PHAC_ASPC_SESSION_COOKIE_AGE`.  By default the declared variable name is
+prefixed with `PHAC_ASPC_`.  The prefix can be changed by providing a custom
+prefix.
+
+```python
+from .utils import global_from_env
+
+global_from_env(
+    prefix='MY_PREFIX_',
+    SESSION_COOKIE_AGE=(int, 1200),
+)
+```
+
+### Environment variable list
+
+All variables are prefixed with `PHAC_ASPC_` to avoid name conflicts.  
+
+| Variable                        | Type | Purpose                         |
+| ------------------------------- | ---- | ------------------------------- |
+| PHAC_ASPC_SESSION_COOKIE_AGE    | int  | Session expiry in seconds       |
+| PHAC_ASPC_SESSION_COOKIE_SECURE | bool | Use secure cookies (HTTPS only) |
+| PHAC_ASPC_LANGUAGE_CODE         | str  | Default language                |
 
 ## Features
 
@@ -139,6 +197,14 @@ from phac_aspc.django.settings import *
 
 SESSION_COOKIE_AGE=1800
 
+```
+
+Configuration parameters can also be overridden using environment variables.
+For example here is a **.env** file that achieves the same result as above.
+
+```bash
+# .env
+PHAC_ASPC_SESSION_COOKIE_AGE=1800
 ```
 
 > For more information on sessions, refer to Django's

--- a/cspell.json
+++ b/cspell.json
@@ -3,7 +3,16 @@
     "ignorePaths": [],
     "dictionaryDefinitions": [],
     "dictionaries": [],
-    "words": [],
+    "words": [
+        "behaviours",
+        "Belliveau"
+    ],
+    "languageSettings": [
+        {
+            "languageId": "*",
+            "locale": "en-CA,fr-CA"
+        }
+    ],
     "ignoreWords": [
         "aspc",
         "boew",

--- a/phac_aspc/django/admin/decorators/__init__.py
+++ b/phac_aspc/django/admin/decorators/__init__.py
@@ -1,1 +1,2 @@
+"""Admin decorator module"""
 from .admin_decorators import add_admin

--- a/phac_aspc/django/admin/decorators/admin_decorators.py
+++ b/phac_aspc/django/admin/decorators/admin_decorators.py
@@ -1,3 +1,4 @@
+"""Decorators related to django admin"""
 from django.contrib.admin import site, ModelAdmin, TabularInline
 
 from modeltranslation.admin import TranslationAdmin
@@ -5,7 +6,7 @@ from modeltranslation.admin import TranslationAdmin
 from phac_aspc.django.helpers.ready import execute_when_ready
 
 
-class add_admin():
+class add_admin:  # pylint: disable=invalid-name,too-few-public-methods
     """
     Add a model Django's administration interface.
 
@@ -16,11 +17,11 @@ class add_admin():
     Usage:
         >>> from django.db import models
         >>> from phac_aspc.django.admin.decorators import add_admin
-        >>> 
+        >>>
         >>> @add_admin()
         >>> class Person(models.Model):
         >>>     ...
-        >>>     
+        >>>
 
     """
 
@@ -34,12 +35,21 @@ class add_admin():
             opts["inlines"] = []
             if self.inlines is not None:
                 for model in self.inlines:
-                    opts["inlines"].append(type('f"{cls.__name__}_{model}InlineAdmin"',
-                                                (TabularInline,), {'model': model}))
-            
-            base_class = TranslationAdmin if hasattr(cls, '__is_translated_model__') else ModelAdmin
+                    opts["inlines"].append(
+                        type(
+                            'f"{cls.__name__}_{model}InlineAdmin"',
+                            (TabularInline,),
+                            {"model": model},
+                        )
+                    )
 
-            site.register(
-                cls, type('f"{cls.__name__}Admin"', (base_class,), opts))
+            base_class = (
+                TranslationAdmin
+                if hasattr(cls, "__is_translated_model__")
+                else ModelAdmin
+            )
+
+            site.register(cls, type('f"{cls.__name__}Admin"', (base_class,), opts))
+
         execute_when_ready(register_model)
         return cls

--- a/phac_aspc/django/helpers/templates/phac_aspc/helpers/wet/session_timeout.html
+++ b/phac_aspc/django/helpers/templates/phac_aspc/helpers/wet/session_timeout.html
@@ -1,7 +1,6 @@
 <script>
   document.addEventListener('DOMContentLoaded', (event) => {
     if (document.getElementsByTagName('h1').length === 0) {{
-      console.log('fire');
       const h1 = document.createElement('h1');
       h1.setAttribute('style', 'display: none;');
       document.body.appendChild(h1);

--- a/phac_aspc/django/helpers/templatetags/phac_aspc_localization.py
+++ b/phac_aspc/django/helpers/templatetags/phac_aspc_localization.py
@@ -1,7 +1,6 @@
 """Related to implementing WET"""
 from django import template
-from django.utils.translation import to_locale, get_language
-    
+from django.utils.translation import get_language
 
 register = template.Library()
 

--- a/phac_aspc/django/helpers/urls/wet.py
+++ b/phac_aspc/django/helpers/urls/wet.py
@@ -1,5 +1,5 @@
 """Setup URLs for views related to WET"""
-from django.urls import path, include, re_path
+from django.urls import path
 
 from ..views import wet
 

--- a/phac_aspc/django/localization/decorators/localization_decorators.py
+++ b/phac_aspc/django/localization/decorators/localization_decorators.py
@@ -6,12 +6,12 @@ from modeltranslation.translator import translator, TranslationOptions
 from phac_aspc.django.helpers.ready import execute_when_ready
 
 
-class translate():
+class translate:  # pylint: disable=invalid-name,too-few-public-methods
     """Add localization to a model
     Usage:
         >>> from django.db import models
         >>> from phac_aspc.django.localization.decorators import translate
-        >>> 
+        >>>
         >>> @translate('title')
         >>> class Person(models.Model):
         >>>     name = models.CharField(max_length=255)
@@ -32,8 +32,15 @@ class translate():
 
     def __call__(self, cls):
         def register_model():
-            translator.register(cls, type(
-                'f"{cls.__name__}TranslationOptions"', (TranslationOptions,), {'fields': self.fields}))
+            translator.register(
+                cls,
+                type(
+                    'f"{cls.__name__}TranslationOptions"',
+                    (TranslationOptions,),
+                    {"fields": self.fields},
+                ),
+            )
             cls.__is_translated_model__ = True
+
         execute_when_ready(register_model)
         return cls

--- a/phac_aspc/django/localization/hooks.py
+++ b/phac_aspc/django/localization/hooks.py
@@ -1,4 +1,4 @@
-
+"""Hooks module"""
 __author__ = "Luc Belliveau <luc.belliveau@phac.aspc.gc.ca>"
 model_translation_hooks = []
 

--- a/phac_aspc/django/settings/__init__.py
+++ b/phac_aspc/django/settings/__init__.py
@@ -1,3 +1,4 @@
+"""Settings module"""
 from .localization import *
 from .security import *
 from .wet import *

--- a/phac_aspc/django/settings/localization.py
+++ b/phac_aspc/django/settings/localization.py
@@ -1,9 +1,13 @@
 """Recommended localization settings"""
 from django.utils.translation import gettext_lazy as _
 
+from .utils import global_from_env
+
 LANGUAGES = (
-    ('fr-ca', _('French')),
-    ('en-ca', _('English')),
+    ("fr-ca", _("French")),
+    ("en-ca", _("English")),
 )
 
-LANGUAGE_CODE = 'en-ca'
+global_from_env(
+    LANGUAGE_CODE=(str, "en-ca"),
+)

--- a/phac_aspc/django/settings/security.py
+++ b/phac_aspc/django/settings/security.py
@@ -1,8 +1,18 @@
 """Recommended values related to security controls"""
-from django.conf import settings
+from .utils import global_from_env
 
 #  AC-11 - Session controls
-SESSION_COOKIE_AGE=1200 # By default expire sessions in 20 minutes
-SESSION_COOKIE_SECURE=True # Use HTTPS
-SESSION_EXPIRE_AT_BROWSER_CLOSE=True # Sessions close when browser is closed
-SESSION_SAVE_EVERY_REQUEST=True # Every requests extends the session
+global_from_env(
+    # Sessions expire in 20 minutes
+    SESSION_COOKIE_AGE=(int, 1200),
+
+    # Use HTTPS for session cookie
+    SESSION_COOKIE_SECURE=(bool, True),
+
+    # Sessions close when browser is closed
+    SESSION_EXPIRE_AT_BROWSER_CLOSE=(bool, True),
+
+    # Every requests extends the session (This is required for the WET session
+    # plugin to function properly.)
+    SESSION_SAVE_EVERY_REQUEST=(bool, True),
+)

--- a/phac_aspc/django/settings/utils.py
+++ b/phac_aspc/django/settings/utils.py
@@ -1,0 +1,33 @@
+"""This file contains utilities helpful for settings declarations"""
+import inspect
+
+import environ
+
+def global_from_env(prefix='PHAC_ASPC_', **conf):
+    """Create named global variables based on the provided environment variable
+    scheme.  Variables defined in the scheme will be inserted into the calling
+    module's globals and prefixed with `PHAC_ASPC_` when fetching the
+    environment variable.
+
+    prefix can be used to change the environment variable prefix that is added
+    to the beginning on the variables defined in conf.  By default this value is
+    `PHAC_ASPC_`.
+
+    conf is a dictionary used to generate the scheme for django-environ.
+
+    See https://django-environ.readthedocs.io/en/latest/api.html#environ.Env for
+    additional information on the scheme.
+
+    """
+
+    mod = inspect.getmodule(inspect.stack()[1][0])
+
+    scheme = dict()
+    for name, values in conf.items():
+        scheme[f"{prefix}{name}"] = values
+
+    env = environ.Env(**scheme)
+    environ.Env.read_env()
+
+    for name in conf:
+        setattr(mod, name, env(f"{prefix}{name}"))

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,5 +32,4 @@ python_requires = >=3.8
 install_requires =
     Django >= 4.1
     django-modeltranslation == 0.18.4
-
-
+    django-environ >= 0.9.0


### PR DESCRIPTION
Several settings or behaviours implemented by this library can be controlled via
environment variables.  This is done via the
[django-environ](https://django-environ.readthedocs.io/en/latest/) library.
(Refer to their documentation on how to format special data types like lists)
If your project root has a `.env` file, those values will be used.

If you want to use environment variables in your project's configuration, you
can simply reference django-environ directly as it will automatically be
installed.  For example:

```python
import environ

env = environ.Env(DEBUG=(bool, False))
environ.Env.read_env()

DEBUG = env('DEBUG')

```