### PR TITLE
feat: AC-7: Implemented account lockout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,41 +3,41 @@
 Provides a series of helpers to provide a consistent experience across
 PHAC-ASPC's Django based projects.
 
+## Third party applications
+
+By using this library, the following django applications will automatically be
+added to your django project:
+
+- [django-axes](https://django-axes.readthedocs.io/)
+- [django-environ](https://django-environ.readthedocs.io/)
+- [django-modeltranslation](https://django-modeltranslation.readthedocs.io/)
+
 ## Quick start
 
 ```bash
 pip install django-phac_aspc-helpers
 ```
 
-Start by adding `phac_aspc.django.helpers` to your `INSTALLED_APPS`
-setting like this:
-
 ```python
 # settings.py
-INSTALLED_APPS = [
-    ...
-    'phac_aspc.django.helpers',
-]
-```
 
-> Note: The `phac_aspc.django.helpers` must appear *after* any
-> application that will be using it.  Consider placing it as the
-> last application in the list.
-
-To use all recommended default settings, add this line to your project's
-settings file:
-
-```python
-#settings.py
+from phac_aspc.django.settings.utils import configure_apps, configure_middleware
 from phac_aspc.django.settings import *
+
+INSTALLED_APPS = configure_apps([...])
+MIDDLEWARE = configure_middleware([...])
 ```
 
-There are also a number of views available that provide additional functionality
-for things like renewing sessions.  Add them to your project's configuration.
+> Note: Replace [...] above with the corresponding existing configuration from
+> your project.
+
+The `configure_apps` and `configure_middleware` utility functions will insert
+the appropriate applications into their correct location in your project's
+application and middleware lists.
 
 ```python
-
 # urls.py
+
 from  phac_aspc.django.helpers.urls import urlpatterns as phac_aspc_helper_urls
 
 urlpatterns = [
@@ -46,24 +46,27 @@ urlpatterns = [
 ]
 ```
 
-> ## Jinja
->
-> If you are using jinja you can use django template tags by adding
-> them to the global environment like this:
->
-> ```python
-> import phac_aspc.django.helpers.templatetags as phac_aspc
->
-> def environment(**options):
->    env = Environment(**options)
->    env.globals.update({
->       "phac_aspc": phac_aspc,
->    })
->    return env
-> ```
->
-> For more information, refer to the Jinja
-> [documentation](https://jinja.palletsprojects.com/en/3.0.x/api/).
+> Note: Add `*phac_aspc_helper_urls` to the list or `urlpatterns` exported by
+> your project's `urls` module.
+
+### Jinja
+
+If you are using jinja you can use django template tags by adding
+them to the global environment like this:
+
+```python
+import phac_aspc.django.helpers.templatetags as phac_aspc
+
+def environment(**options):
+    env = Environment(**options)
+    env.globals.update({
+       "phac_aspc": phac_aspc,
+    })
+    return env
+```
+
+For more information, refer to the Jinja
+[documentation](https://jinja.palletsprojects.com/en/3.0.x/api/).
 
 ## Environment variables
 
@@ -177,6 +180,41 @@ or if you're using Jinja:
 | Canada.ca (GCWeb)            | v12.5.0   |
 
 ### Security Controls
+
+#### AC-7 Automatic lockout of users after invalid login attempts
+
+[django-axes](https://django-axes.readthedocs.io) is used to monitor and lockout
+users who fail to successfully authenticate.
+
+The default configuration makes the following configuration changes to django:
+
+- An attempt is identified by the combination of incoming IP address and
+  the username,
+- Both successful logins and failures are recorded to the database,
+- The django project is assumed to be behind 1 reverse proxy (SSL),
+- After 3 login failures, the account is locked out for 30 minutes.
+
+To require an administrator to unlock the account, or to alter the lockout
+duration, you can modify the `AXES_COOLOFF_TIME` setting.
+
+```python
+# settings.py
+
+# Examples of AXES_COOLOFF_TIME settings
+AXES_COOLOFF_TIME = None   # An administrator must unlock the account
+AXES_COOLOFF_TIME = 2      # Accounts will be locked out for 2 hours
+```
+For more information regarding available configuration options, visit
+django-axes's [documentation](https://django-axes.readthedocs.io/en/latest/4_configuration.html)
+
+There are also a few command line management commands available, for example to
+remove all of the lockouts you can run:
+
+```bash
+python -m manage axes_reset
+```
+See the [usage](https://django-axes.readthedocs.io/en/latest/3_usage.html)
+documentation for more details.
 
 #### AC-11 Session Timeouts
 

--- a/cspell.json
+++ b/cspell.json
@@ -25,7 +25,8 @@
         "phac",
         "reactionTime",
         "sessionalive",
-        "urlpatterns"
+        "urlpatterns",
+        "COOLOFF"
     ],
     "import": []
 }

--- a/phac_aspc/django/settings/security.py
+++ b/phac_aspc/django/settings/security.py
@@ -1,5 +1,29 @@
 """Recommended values related to security controls"""
-from .utils import global_from_env
+from .utils import global_from_env, configure_authentication_backends
+
+#  AC-7 Automatic lockout of users after invalid login attempts
+AUTHENTICATION_BACKENDS = configure_authentication_backends([
+    'django.contrib.auth.backends.ModelBackend',
+])
+
+# Lockout users based on their username and IP address
+AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP = True
+
+# Log unsuccessful logins
+AXES_ENABLE_ACCESS_FAILURE_LOG = True
+
+# After 3 failed login attempts, lock out the combination (IP + user).
+AXES_FAILURE_LIMIT = 3
+
+# After 30 minutes, locked out accounts are automatically unlocked.
+AXES_COOLOFF_TIME = 0.5
+
+# Reverse proxy configuration
+AXES_PROXY_COUNT = 1  # (Behind 1 proxy)
+AXES_META_PRECEDENCE_ORDER = [
+    'HTTP_X_FORWARDED_FOR',
+    'REMOTE_ADDR',
+]
 
 #  AC-11 - Session controls
 global_from_env(

--- a/phac_aspc/django/settings/test_utils.py
+++ b/phac_aspc/django/settings/test_utils.py
@@ -1,0 +1,122 @@
+"""Unit tests for utils.py"""
+from django.core.checks.registry import registry
+
+from .utils import (
+    trigger_configuration_warning,
+    warn_and_remove,
+    configure_apps,
+    configure_authentication_backends,
+    configure_middleware,
+)
+
+
+def test_trigger_configuration_warning():
+    """Test the trigger configuration warning successfully registers its
+    check function"""
+    num = len(registry.get_checks())
+    msg = "this is a warning"
+    trigger_configuration_warning(msg)
+    assert len(registry.get_checks()) == num + 1
+    assert "phac_aspc_conf_warning" in [i.__name__ for i in registry.get_checks()]
+    for i in registry.get_checks():
+        if i.__name__ == "phac_aspc_conf_warning":
+            warn = i(None)
+            assert len(warn) == 1
+            assert warn[0].msg == msg
+
+
+def test_warn_and_remove():
+    """Test that if an item appears in the list, it is removed from the result
+    and a configuration warning is called."""
+    num = len(registry.get_checks())
+    test = warn_and_remove(["a", "b"], ["c"])
+    assert len(registry.get_checks()) == num
+    assert test == ["a", "b"]
+
+    num = len(registry.get_checks())
+    test = warn_and_remove(["a", "b", "c", "d"], ["c"])
+    assert len(registry.get_checks()) == num + 1
+    assert test == ["a", "b", "d"]
+
+    num = len(registry.get_checks())
+    test = warn_and_remove(["a", "b", "c", "d"], ["a", "b", "c"])
+    assert len(registry.get_checks()) == num + 3
+    assert test == ["d"]
+
+    num = len(registry.get_checks())
+    test = warn_and_remove(["a", "b", "c", "d"], [])
+    assert len(registry.get_checks()) == num
+    assert test == ["a", "b", "c", "d"]
+
+    num = len(registry.get_checks())
+    test = warn_and_remove([], [])
+    assert len(registry.get_checks()) == num
+    assert not test
+
+    num = len(registry.get_checks())
+    test = warn_and_remove(["a", "b", "c", "d"], ["a", "b", "c", "d"])
+    assert len(registry.get_checks()) == num + 4
+    assert not test
+
+
+def test_configure_apps():
+    """Test that the configure apps utility adds the correct apps"""
+    num = len(registry.get_checks())
+    test = configure_apps([])
+    assert test == ["modeltranslation", "axes", "phac_aspc.django.helpers"]
+    assert len(registry.get_checks()) == num
+
+    num = len(registry.get_checks())
+    test = configure_apps(["a", "b"])
+    assert test == ["modeltranslation", "axes", "a", "b", "phac_aspc.django.helpers"]
+    assert len(registry.get_checks()) == num
+
+    num = len(registry.get_checks())
+    test = configure_apps(["a", "axes", "b"])
+    assert test == ["modeltranslation", "a", "axes", "b", "phac_aspc.django.helpers"]
+    assert len(registry.get_checks()) == num + 1
+
+    num = len(registry.get_checks())
+    test = configure_apps(["phac_aspc.django.helpers", "axes", "b"])
+    assert test == ["modeltranslation", "phac_aspc.django.helpers", "axes", "b"]
+    assert len(registry.get_checks()) == num + 2
+
+
+def test_configure_authentication_backends():
+    """Test that the configure_authentication_backends utility adds the correct
+    backends to the list"""
+    num = len(registry.get_checks())
+    test = configure_authentication_backends([])
+    assert test == ["axes.backends.AxesStandaloneBackend"]
+    assert len(registry.get_checks()) == num
+
+    num = len(registry.get_checks())
+    test = configure_authentication_backends(["a", "b"])
+    assert test == ["axes.backends.AxesStandaloneBackend", "a", "b"]
+    assert len(registry.get_checks()) == num
+
+    num = len(registry.get_checks())
+    test = configure_authentication_backends(
+        ["a", "axes.backends.AxesStandaloneBackend", "b"]
+    )
+    assert test == ["a", "axes.backends.AxesStandaloneBackend", "b"]
+    assert len(registry.get_checks()) == num + 1
+
+
+def test_configure_middleware():
+    """Test that the configure_middleware utility adds the correct middleware to
+    the list"""
+    num = len(registry.get_checks())
+    test = configure_middleware([])
+    assert test == ["axes.middleware.AxesMiddleware"]
+    assert len(registry.get_checks()) == num
+
+    num = len(registry.get_checks())
+    test = configure_middleware(["a", "b"])
+    assert test == ["axes.middleware.AxesMiddleware", "a", "b"]
+    assert len(registry.get_checks()) == num
+
+    num = len(registry.get_checks())
+    test = configure_middleware(["a", "axes.middleware.AxesMiddleware", "b"])
+    assert test == ["a", "axes.middleware.AxesMiddleware", "b"]
+    assert len(registry.get_checks()) == num + 1

--- a/phac_aspc/django/settings/utils.py
+++ b/phac_aspc/django/settings/utils.py
@@ -3,6 +3,67 @@ import inspect
 
 import environ
 
+from django.core import checks
+
+
+def trigger_configuration_warning(msg, **kwargs):
+    """Trigger a configuration error programmatically"""
+
+    def phac_aspc_conf_warning(app_configs, **conf_kwargs):  # pylint: disable=unused-argument
+        return [checks.Warning(msg, **kwargs)]
+
+    checks.register(phac_aspc_conf_warning)
+
+
+def warn_and_remove(items, dest_list):
+    """If the items intersects with dest_list, raise a configuration warning and
+    remove it from the list returned to prevent errors."""
+    ret = []
+    context = inspect.stack()[1].function
+    hint = "You should remove it from your project to ensure proper ordering."
+
+    for item in items:
+        if item in dest_list:
+            trigger_configuration_warning(
+                f"{item} is already defined in the provided list.",
+                id=context,
+                hint=hint,
+            )
+            hint = None
+        else:
+            ret.append(item)
+    return ret
+
+
+def configure_apps(app_list):
+    """Return an application list which includes the apps required by this
+    library"""
+
+    prefix_list = warn_and_remove(["modeltranslation", "axes"], app_list)
+    suffix_list = warn_and_remove(["phac_aspc.django.helpers"], app_list)
+
+    return prefix_list + app_list + suffix_list
+
+
+def configure_authentication_backends(backend_list):
+    """Return the authentication backend list includes those required by this
+    library.
+
+    By default importing the settings will automatically configure the backend,
+    however if you want to customize the authentication backend used by your
+    project, you can use this method to ensure proper configuration."""
+
+    prefix_backends = warn_and_remove(
+        ["axes.backends.AxesStandaloneBackend"], backend_list
+    )
+    return prefix_backends + backend_list
+
+
+def configure_middleware(middleware_list):
+    """Return the list of middleware configured for this library"""
+    suffix = warn_and_remove(["axes.middleware.AxesMiddleware"], middleware_list)
+    return suffix + middleware_list
+
 
 def global_from_env(prefix="PHAC_ASPC_", **conf):
     """Create named global variables based on the provided environment variable

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Localization
@@ -30,6 +32,7 @@ packages = find:
 
 python_requires = >=3.8
 install_requires =
-    Django >= 4.1
+    Django == 4.1
     django-modeltranslation == 0.18.4
-    django-environ >= 0.9.0
+    django-environ == 0.9.0
+    django-axes == 5.40.1


### PR DESCRIPTION

Relates to AB#3772

- An attempt is identified by the combination of incoming IP address and
  the username,
- Both successful logins and failures are recorded to the database,
- The django project is assumed to be behind 1 reverse proxy (SSL),
- After 3 login failures, the account is locked out for 30 minutes.
