### PR TITLE
feat: support URL query params (including 'next' redirect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ After successful authentication, the user is redirected to `/`.  To customize
 this behaviour, set `PHAC_ASPC_OAUTH_REDIRECT_ON_LOGIN` in `settings.py` to the
 name of the desired route.
 
+Redirecting to a specific page is also supported through the `?next=<url>` query parameter. See "Template Tag" examples below.
+
 ```python
 
 PHAC_ASPC_OAUTH_USE_BACKEND = "custom.authentication.backend"
@@ -294,6 +296,15 @@ A "Sign in with Microsoft" button is available as a template tag:
 {% load phac_aspc_auth %}
 {% phac_aspc_auth_signin_microsoft_button %}
 ```
+
+To redirect to a specific page after logging in, pass the `next` query parameter through to the template tag as an argument.
+
+e.g. with Jinja, on a login page where the URL ends with `?next=/some-protected-page/`:
+
+```
+{{ phac_aspc.phac_aspc_auth_signin_microsoft_button(request.GET.urlencode()) }}
+```
+
 
 #### Handling Errors
 

--- a/phac_aspc/django/helpers/auth/views.py
+++ b/phac_aspc/django/helpers/auth/views.py
@@ -1,11 +1,13 @@
 """OAuth authentication related views"""
+from urllib import parse
+
+from django.conf import settings
+from django.contrib.auth import authenticate
+from django.contrib.auth import login as auth_login
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
-from django.contrib.auth import authenticate
 from django.urls import reverse
-from django.contrib.auth import login as auth_login
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 
 from authlib.integrations.django_client import OAuth, OAuthError
 
@@ -31,8 +33,11 @@ def login(request):
     """Redirect users to the provider's login page"""
     if PROVIDER:
         client = oauth.create_client(PROVIDER)
+        auth_url_extra_params = {"state": request.build_absolute_uri()}
         return client.authorize_redirect(
-            request, request.build_absolute_uri(reverse("phac_aspc_authorize"))
+            request,
+            request.build_absolute_uri(reverse("phac_aspc_authorize")),
+            **auth_url_extra_params
         )
     raise ImproperlyConfigured("The login route is not configured.")
 
@@ -47,6 +52,9 @@ def authorize(request):
                 claims_options={"iss": {"essential": True, "validate": validate_iss}},
             )
             user_info = token["userinfo"]
+            query_params = dict(
+                parse.parse_qsl(parse.urlsplit(request.GET["state"]).query)
+            )
             user = authenticate(request, user_info=user_info)
             if user is not None:
                 auth_login(
@@ -54,6 +62,10 @@ def authorize(request):
                     user=user,
                     backend=BACKEND,
                 )
+
+                if "next" in query_params:
+                    return HttpResponseRedirect(query_params["next"])
+
                 return HttpResponseRedirect(
                     reverse(REDIRECT_LOGIN) if REDIRECT_LOGIN else "/"
                 )

--- a/phac_aspc/django/helpers/templates/phac_aspc/helpers/auth/buttons/microsoft.html
+++ b/phac_aspc/django/helpers/templates/phac_aspc/helpers/auth/buttons/microsoft.html
@@ -13,13 +13,13 @@
         display: inline-flex;
         padding: 0 12px 0 0;
         text-decoration: none;
-        }
-        
-        .btn-ms-login img {
+    }
+    
+    .btn-ms-login img {
         margin: 0 12px 0 12px;
-        }
+    }
 </style>
-<a href="{% url 'phac_aspc_helper_login' %}"
+<a href="{% url 'phac_aspc_helper_login' %}{% if query_params %}?{{query_params}}{% endif %}"
    class="btn-ms-login align-self-end">
     <img width="21"
          height="21"

--- a/phac_aspc/django/helpers/templatetags/phac_aspc_auth.py
+++ b/phac_aspc/django/helpers/templatetags/phac_aspc_auth.py
@@ -1,17 +1,19 @@
 """Related to Authentication"""
 from django import template
-from django.template import loader
 from django.conf import settings
+from django.template import loader
 
 register = template.Library()
 
 
 @register.simple_tag()
-def phac_aspc_auth_signin_microsoft_button():
+def phac_aspc_auth_signin_microsoft_button(query_params=""):
     """Returns a signin button using the microsoft design"""
 
     return (
-        loader.get_template("phac_aspc/helpers/auth/buttons/microsoft.html").render()
+        loader.get_template("phac_aspc/helpers/auth/buttons/microsoft.html").render(
+            {"query_params": query_params}
+        )
         if getattr(settings, "PHAC_ASPC_HELPER_OAUTH_PROVIDER", False)
         else ""
     )


### PR DESCRIPTION
Actually written by @Dhanani 

This is just a redo of this PR https://github.com/PHACDataHub/django-phac_aspc-helpers/pull/23 to meet the repo requirements about Verified commits.