### PR TITLE
Templatetag for inlining svg content from an svg file

### DIFF
--- a/phac_aspc/django/helpers/templatetags/__init__.py
+++ b/phac_aspc/django/helpers/templatetags/__init__.py
@@ -9,6 +9,7 @@ from .phac_aspc_wet import (
 )
 from .phac_aspc_auth import phac_aspc_auth_signin_microsoft_button
 from .phac_aspc_include_from_jinja import phac_aspc_include_from_jinja
+from .phac_aspc_inline_svg import phac_aspc_inline_svg
 
 __all__ = [
     "phac_aspc_localization_lang",
@@ -19,4 +20,5 @@ __all__ = [
     "phac_aspc_wet_session_timeout_dialog",
     "phac_aspc_auth_signin_microsoft_button",
     "phac_aspc_include_from_jinja",
+    "phac_aspc_inline_svg",
 ]

--- a/phac_aspc/django/helpers/templatetags/phac_aspc_inline_svg.py
+++ b/phac_aspc/django/helpers/templatetags/phac_aspc_inline_svg.py
@@ -1,0 +1,35 @@
+from xml.etree import ElementTree
+
+from django import template
+from django.contrib.staticfiles import finders
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def phac_aspc_inline_svg(static_file_path=None, **kwargs):
+    """Inlines a SVG icon from linkcube/src/core/assets/templates/core.assets/icon
+
+    Based on https://stackoverflow.com/a/68802035
+
+    Example usage:
+        {% phac_aspc_inline_svg "phac_aspc_helpers/phac_logos/en.svg" height="2rem" %}
+    Parameter: static_file_path
+        Path of the svg to be inlined; resolved relative to the static root(s) of installed apps.
+    Parameter: kwargs
+        Additional kwargs are treated as attribute:value pairs and set on the svg's root node.
+    Returns:
+        stringified XML to be inlined, i.e.:
+        '<svg class="..." height="...">...</svg>'
+    """
+    ElementTree.register_namespace("", "http://www.w3.org/2000/svg")
+
+    svg_root = ElementTree.parse(finders.find(static_file_path)).getroot()
+
+    for attribute, value in kwargs.items():
+        svg_root.set(attribute, value)
+
+    svg_string = ElementTree.tostring(svg_root, encoding="unicode", method="html")
+
+    return mark_safe(svg_string)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -70,6 +70,11 @@ TEMPLATES = [
     },
 ]
 
+STATICFILES_DIRS = glob(
+    str(Path(__file__).parent.joinpath("**/static")),
+    recursive=True,
+)
+
 
 DATABASES = {
     "default": {

--- a/testapp/tests/django/helpers/templatetags/static/test_phac_aspc_inline_svg.svg
+++ b/testapp/tests/django/helpers/templatetags/static/test_phac_aspc_inline_svg.svg
@@ -1,0 +1,3 @@
+<svg>
+  <text>test</text>
+</svg>

--- a/testapp/tests/django/helpers/templatetags/test_phac_aspc_inline_svg.py
+++ b/testapp/tests/django/helpers/templatetags/test_phac_aspc_inline_svg.py
@@ -1,0 +1,49 @@
+import os
+import re
+
+from django.template import Template, Context
+
+test_svg_name = "test_phac_aspc_inline_svg.svg"
+
+
+def test_phac_aspc_inline_svg_inlines_svg_content_from_file():
+    with open(
+        os.path.join(os.path.dirname(__file__), "static", test_svg_name),
+        "r",
+        encoding="UTF-8",
+    ) as svg_file:
+        svg_file_content = svg_file.read()
+
+        template_with_inlined_svg = Template(
+            "{% load phac_aspc_inline_svg %}\n"
+            + f"{{% phac_aspc_inline_svg '{test_svg_name}' %}}"
+        ).render(Context({}))
+
+        assert svg_file_content.strip() == template_with_inlined_svg.strip()
+
+
+def test_phac_aspc_inline_svg_sets_provided_attributes():
+    svg_name = "test_phac_aspc_inline_svg.svg"
+
+    attribute1 = "width"
+    value1 = "2rem"
+
+    attribute2 = "class"
+    value2 = "some-class"
+
+    template_with_inlined_svg = Template(
+        "{% load phac_aspc_inline_svg %}\n"
+        + f"{{% phac_aspc_inline_svg '{svg_name}' "
+        + f"{attribute1}='{value1}' {attribute2}='{value2}' %}}"
+    ).render(Context({}))
+
+    for attribute, value in [[attribute1, value1], [attribute2, value2]]:
+        assert (
+            len(
+                re.findall(
+                    f"<svg .*{attribute}=['\"]{value}['\"].*>",
+                    template_with_inlined_svg,
+                )
+            )
+            == 1
+        )


### PR DESCRIPTION
Inlines the content of a svg from static files in to a template. There are cases where this is going to be preferred over an `<img src="...">` or `<object...`. E.g. if the svg itself includes a11y markup (`img` is opaque to that, `object` is reportedly inconsistent depending on browser and screen reader).

Jinja templates can use this too, via the standard pattern of adding templatetags to the jinja `env.globals`. I could extract it in to a util that could be used directly in jinja, and just wrap that for a templatetag, but ehh.