### PR TITLE
feat: add rules utility

### DIFF
--- a/phac_aspc/django/settings/utils/configuration_verification_utils.py
+++ b/phac_aspc/django/settings/utils/configuration_verification_utils.py
@@ -42,7 +42,13 @@ def configure_apps(app_list):
     library"""
 
     prefix_list = warn_and_remove(["modeltranslation", "axes"], app_list)
-    suffix_list = warn_and_remove(["phac_aspc.django.helpers"], app_list)
+    suffix_list = warn_and_remove(
+        [
+            "phac_aspc.django.helpers",
+            "rules.apps.AutodiscoverRulesConfig",
+        ],
+        app_list,
+    )
 
     return prefix_list + app_list + suffix_list
 

--- a/phac_aspc/rules.py
+++ b/phac_aspc/rules.py
@@ -1,0 +1,68 @@
+# This module is a wrapper around the django-rules package
+from unittest.mock import patch
+
+import rules
+from rules import add_rule, predicate
+
+
+class NonExistentRuleException(Exception):
+    pass
+
+
+# this is the "private" version, for mocking purposes
+def _test_rule(name, user=None, obj=None):
+    if not rules.rule_exists(name):
+        raise NonExistentRuleException(f"rule {name} does not exist")
+    else:
+        return rules.test_rule(name, user, obj)
+
+
+def test_rule(*args, **kwargs):
+    return _test_rule(*args, **kwargs)
+
+
+def auto_rule(fn):
+    """
+    use as decorator, e.g.
+
+    @auto_rule
+    def rule_name(user, obj):
+        ...
+
+
+    is shorthand for
+
+    add_rule("rule_name", rule_name_func)
+
+    """
+    pred = predicate(fn)
+    add_rule(fn.__name__, pred)
+    return pred
+
+
+class patch_rules:
+    """
+    usage: with mock_rules(can_access_foo=False):
+      assert test_client.get(some_view_that_uses_patched_rules).status_code == 403
+    """
+
+    def rule_mocker(self, **rule_stubs):
+        def exec_rule(rule_name, user=None, obj=None):
+            if rule_name in rule_stubs:
+                return rule_stubs[rule_name]
+            else:
+                return self.actual_rule_func(rule_name, user, obj)
+
+        return exec_rule
+
+    def __init__(self, **rule_stubs):
+        self.actual_rule_func = _test_rule
+        self._patch = patch(
+            "phac_aspc.rules._test_rule", self.rule_mocker(**rule_stubs)
+        )
+
+    def __enter__(self):
+        return self._patch.__enter__()
+
+    def __exit__(self, *excp):
+        return self._patch.__exit__(*excp)

--- a/phac_aspc/rules.py
+++ b/phac_aspc/rules.py
@@ -13,8 +13,8 @@ class NonExistentRuleException(Exception):
 def _test_rule(name, user=None, obj=None):
     if not rules.rule_exists(name):
         raise NonExistentRuleException(f"rule {name} does not exist")
-    else:
-        return rules.test_rule(name, user, obj)
+
+    return rules.test_rule(name, user, obj)
 
 
 def test_rule(*args, **kwargs):
@@ -50,8 +50,8 @@ class patch_rules:
         def exec_rule(rule_name, user=None, obj=None):
             if rule_name in rule_stubs:
                 return rule_stubs[rule_name]
-            else:
-                return self.actual_rule_func(rule_name, user, obj)
+
+            return self.actual_rule_func(rule_name, user, obj)
 
         return exec_rule
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,5 @@ install_requires =
     django-environ == 0.11.2
     django-axes[ipware] == 6.1.1
     django-structlog == 5.3.0
+    rules==3.3
+

--- a/testapp/tests/django/settings/test_utils.py
+++ b/testapp/tests/django/settings/test_utils.py
@@ -92,22 +92,47 @@ def test_configure_apps():
     """Test that the configure apps utility adds the correct apps"""
     num = len(registry.get_checks())
     test = configure_apps([])
-    assert test == ["modeltranslation", "axes", "phac_aspc.django.helpers"]
+    assert test == [
+        "modeltranslation",
+        "axes",
+        "phac_aspc.django.helpers",
+        "rules.apps.AutodiscoverRulesConfig",
+    ]
     assert len(registry.get_checks()) == num
 
     num = len(registry.get_checks())
     test = configure_apps(["a", "b"])
-    assert test == ["modeltranslation", "axes", "a", "b", "phac_aspc.django.helpers"]
+    assert test == [
+        "modeltranslation",
+        "axes",
+        "a",
+        "b",
+        "phac_aspc.django.helpers",
+        "rules.apps.AutodiscoverRulesConfig",
+    ]
     assert len(registry.get_checks()) == num
 
     num = len(registry.get_checks())
     test = configure_apps(["a", "axes", "b"])
-    assert test == ["modeltranslation", "a", "axes", "b", "phac_aspc.django.helpers"]
+    assert test == [
+        "modeltranslation",
+        "a",
+        "axes",
+        "b",
+        "phac_aspc.django.helpers",
+        "rules.apps.AutodiscoverRulesConfig",
+    ]
     assert len(registry.get_checks()) == num + 1
 
     num = len(registry.get_checks())
     test = configure_apps(["phac_aspc.django.helpers", "axes", "b"])
-    assert test == ["modeltranslation", "phac_aspc.django.helpers", "axes", "b"]
+    assert test == [
+        "modeltranslation",
+        "phac_aspc.django.helpers",
+        "axes",
+        "b",
+        "rules.apps.AutodiscoverRulesConfig",
+    ]
     assert len(registry.get_checks()) == num + 2
 
 

--- a/testapp/tests/test_rules.py
+++ b/testapp/tests/test_rules.py
@@ -1,0 +1,34 @@
+from phac_aspc.rules import (
+    # must be imported in form that doesn't start with test_
+    # otherwise pytest will try to run it as a test
+    test_rule as func_test_rule,
+    patch_rules,
+    add_rule,
+    auto_rule,
+)
+
+
+def test_rules():
+    @auto_rule
+    def has_foo_access(user, obj):
+        return True
+
+    # also test manually added rule
+    def has_bar_access_func(user, obj):
+        return False
+
+    add_rule("has_bar_access", has_bar_access_func)
+
+    # test_rule works with 1, 2, or 3 arguments
+    assert func_test_rule("has_foo_access")
+    assert func_test_rule("has_foo_access", 1)
+    assert func_test_rule("has_foo_access", 1, 1)
+    assert not func_test_rule("has_bar_access")
+
+    with patch_rules(has_foo_access=False, has_bar_access=True):
+        assert func_test_rule("has_bar_access")
+        assert not func_test_rule("has_foo_access")
+
+    # rules are returned to normal after patch_rules
+    assert not func_test_rule("has_bar_access")
+    assert func_test_rule("has_foo_access")


### PR DESCRIPTION
Copy-pasting the rules stuff verbatim at least 4 times has got me thinking it should just go in here. It's relatively isolated, some utils and test utils, an additional INSTALLED_APPS reduces quite a foot print in projects