### PR TITLE
fix: replace comma-separated fields' lists with tuples

### DIFF
--- a/phac_aspc/django/comma_separated_field.py
+++ b/phac_aspc/django/comma_separated_field.py
@@ -106,13 +106,13 @@ class BaseSeparatedValuesField(models.Field):
 
     def to_python(self, value):
         if not value:
-            return []
+            return tuple()
 
         values = value
         if isinstance(value, str):
             values = value.split(self.token)
 
-        return [self.cast(v) for v in values]
+        return tuple(self.cast(v) for v in values)
 
     def get_db_prep_value(self, value, *args, **kwargs):
         if isinstance(value, (list, tuple)):

--- a/testapp/tests/django/test_comma_separated_field.py
+++ b/testapp/tests/django/test_comma_separated_field.py
@@ -9,8 +9,8 @@ def test_csv_field_on_create():
         tag_categories=["fiction", "biography"],
         tag_categories_text=["fiction", "history"],
     )
-    assert tag.tag_categories == ["fiction", "biography"]
-    assert tag.tag_categories_text == ["fiction", "history"]
+    assert tag.tag_categories == ("fiction", "biography")
+    assert tag.tag_categories_text == ("fiction", "history")
     assert Tag.objects.filter(
         tag_categories="fiction,biography", tag_categories_text="fiction,history"
     ).exists()
@@ -19,7 +19,7 @@ def test_csv_field_on_create():
 def test_csv_char_field():
     tag = Tag.objects.create()
 
-    assert tag.tag_categories == []
+    assert tag.tag_categories == tuple()
     tag.tag_categories = [
         "fiction",
         "history",
@@ -27,10 +27,10 @@ def test_csv_char_field():
     tag.save()
 
     tag.refresh_from_db()
-    assert tag.tag_categories == [
+    assert tag.tag_categories == (
         "fiction",
         "history",
-    ]
+    )
     assert Tag.objects.filter(tag_categories="fiction,history").exists()
 
     # test forms work too
@@ -40,10 +40,10 @@ def test_csv_char_field():
             fields = ["tag_categories"]
 
     read_form = SystemOverviewForm(instance=tag)
-    assert read_form.initial["tag_categories"] == [
+    assert read_form.initial["tag_categories"] == (
         "fiction",
         "history",
-    ]
+    )
     assert read_form.fields["tag_categories"].choices[0][0] == "fiction"
 
     bad_form = SystemOverviewForm(
@@ -70,10 +70,10 @@ def test_csv_char_field():
     write_form.save()
 
     tag.refresh_from_db()
-    assert tag.tag_categories == [
+    assert tag.tag_categories == (
         "fiction",
         "history",
-    ]
+    )
 
     # now check the raw DB value is "" if we set it to []
     tag.tag_categories = []
@@ -90,7 +90,7 @@ def test_csv_char_field():
 def test_csv_text_field():
     tag = Tag.objects.create()
 
-    assert tag.tag_categories_text == []
+    assert tag.tag_categories_text == tuple()
     tag.tag_categories_text = [
         "fiction",
         "history",
@@ -98,10 +98,10 @@ def test_csv_text_field():
     tag.save()
 
     tag.refresh_from_db()
-    assert tag.tag_categories_text == [
+    assert tag.tag_categories_text == (
         "fiction",
         "history",
-    ]
+    )
     assert Tag.objects.filter(tag_categories_text="fiction,history").exists()
 
     # test forms work too
@@ -111,10 +111,10 @@ def test_csv_text_field():
             fields = ["tag_categories_text"]
 
     read_form = SystemOverviewForm(instance=tag)
-    assert read_form.initial["tag_categories_text"] == [
+    assert read_form.initial["tag_categories_text"] == (
         "fiction",
         "history",
-    ]
+    )
     assert read_form.fields["tag_categories_text"].choices[0][0] == "fiction"
 
     bad_form = SystemOverviewForm(
@@ -141,13 +141,13 @@ def test_csv_text_field():
     write_form.save()
 
     tag.refresh_from_db()
-    assert tag.tag_categories_text == [
+    assert tag.tag_categories_text == (
         "fiction",
         "history",
-    ]
+    )
 
     # now check the raw DB value is "" if we set it to []
-    tag.tag_categories_text = []
+    tag.tag_categories_text = tuple()
     tag.save()
 
     # perform a raw query


### PR DESCRIPTION
tuples have a ton of advantages, I should have used them to begin with


- Tuples are immutable. I was always worried about someone modifying the lists directly via something like append. I'm not sure how much of a footgun that was, but tuples make sure we can sidestep that issue
- lists aren't hashable which made the changelog crash (tuples are still ugly, and this will require a changelog rewrite, but at least they don't break it)