### PR TITLE
feat: Writer api change

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+    venv/*
+    env/*
+    */migrations/*
+    */scripts/*
+    tests/*
+    htmlcov/
+    test_.*py

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,7 @@ disable=
     R0913, # Too many arguments
     R0914, # Too many local vars
     R0901, # too many ancestors (max 7)
+    E1102, # not callable (per-line disable wouldn't work)
 
 [CLASSES]
 # pylint complains when you access 'protected' attributes (anything that starts with _), here are exceptions we support

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ library; refer to their documentation on how to format special data types like l
 Alternatively, these environment variables can be declared in your `settings.py`
 itself. There are two important caveats when doing so:
 
-  1) `settings.py` declarations take precedence over any instances of the same
-  env var in your `.env` file
-  2) any env vars declared in `settings.py` for this library **must** be declared
-  **before** any imports from `phac_aspc` occur!
-     - similarly, you should not consume`phac_aspc` modules anywhere that executes
+1. `settings.py` declarations take precedence over any instances of the same
+   env var in your `.env` file
+2. any env vars declared in `settings.py` for this library **must** be declared
+   **before** any imports from `phac_aspc` occur!
+   - similarly, you should not consume`phac_aspc` modules anywhere that executes
      prior to Django's consumption of your app's settings module (e.g. in `manage.py`)
-     - `phac_aspc` modules that don't, directly or indirectly, depend on these
+   - `phac_aspc` modules that don't, directly or indirectly, depend on these
      env vars are theoretically safe anywhere, **but** we don't currently identify
      these modules, or make promises that any given module won't start depending
      on env vars in the future
@@ -203,11 +203,11 @@ the redirect route named `phac_aspc_authorize` along with a token containing
 information about the user.
 
 By default, the authentication backend will look for a user who's username is
-the user's uuid from Microsoft - if not found a new user is created.  To
+the user's uuid from Microsoft - if not found a new user is created. To
 customize this behaviour, a custom authentication backend class can be specified
 via `PHAC_ASPC_OAUTH_USE_BACKEND` in `settings.py`.
 
-After successful authentication, the user is redirected to `/`.  To customize
+After successful authentication, the user is redirected to `/`. To customize
 this behaviour, set `PHAC_ASPC_OAUTH_REDIRECT_ON_LOGIN` in `settings.py` to the
 name of the desired route.
 
@@ -311,15 +311,15 @@ e.g. with Jinja, on a login page where the URL ends with `?next=/some-protected-
 
 If there are any errors during the authentication flow, they are displayed to
 the user via the [error.html](phac_aspc/django/helpers/templates/phac_aspc/helpers/auth/error.html)
-template.  The template can be extended using standard django templating by
+template. The template can be extended using standard django templating by
 creating a `templates/phac_aspc/helpers/auth/error.html` file in the host
 project.
 
 #### Strings and locales
 
 Strings displayed to the user during the authentication flow are available in
-Canada's both official languages.  These strings can be customized by creating
-templates in the host project.  Here is a list of strings and templates used by
+Canada's both official languages. These strings can be customized by creating
+templates in the host project. Here is a list of strings and templates used by
 the authentication flow:
 
 | Template                    | Context                                              |
@@ -455,9 +455,9 @@ can be changed in your projects settings using `LANGUAGES` and `LANGUAGE_CODE`.
 
 #### Localization Environment variables
 
-| Variable                        | Type | Purpose                         |
-| ------------------------------- | ---- | ------------------------------- |
-| PHAC_ASPC_LANGUAGE_CODE         | str  | Default language                |
+| Variable                | Type | Purpose          |
+| ----------------------- | ---- | ---------------- |
+| PHAC_ASPC_LANGUAGE_CODE | str  | Default language |
 
 #### lang template tag
 
@@ -537,7 +537,7 @@ import phac_aspc.django.helpers.jinja_utils as include_from_dtl
 def environment(**options):
     env = Environment(**options)
     env.globals.update({
-       ..., # other utils and constants 
+       ..., # other utils and constants
        "include_from_dtl": include_from_dtl,
     })
     return env
@@ -678,3 +678,10 @@ You can consume the helpers project locally by installing it in editable mode. T
 ```ini
 -e file:///absolute_path/to/django-phac_aspc-helpers
 ```
+
+### Generating test coverage
+
+1. `coverage run --source=. ./manage.py test`
+2. `coverage html`
+3. `python -m http.server 1337`
+4. visit `http://localhost:1337/htmlcov/` and dig into modules to see which individual line coverage

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -177,13 +177,22 @@ class ManyToManyColumn(Column):
         return self.delimiter.join([self.get_related_str(x) for x in related_records])
 
 
+class WriterConfigException(Exception):
+    pass
+
+
 class AbstractWriter:
     iterator = None
 
     def __init__(self, iterator=None):
-        self.iterator = iterator
+        if iterator is not None:
+            self.iterator = iterator
 
     def get_iterator(self):
+        if self.iterator is None:
+            raise NotImplementedError(
+                "must set iterator in init, class or override get_iterator()"
+            )
         return self.iterator
 
     def get_header_row(self):
@@ -200,24 +209,33 @@ class AbstractWriter:
 class AbstractModelWriter(AbstractWriter):
     # pylint: disable=W0223
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        assert isinstance(
-            self.iterator, QuerySet
-        ), "iterator must be queryset, otherwise use AbstracWriter"
+    def __init__(self, **kwargs):
+        if "iterator" in kwargs:
+            raise WriterConfigException(
+                "don't use iterator kwarg, use the queryset kwarg, class attr or override get_queryset()"
+            )
+        if "queryset" in kwargs:
+            self.queryset = kwargs.pop("queryset")
+
+        super().__init__(**kwargs)
 
     def get_iterator(self):
-        return self.get_queryset()
+        return page_queryset(self.get_queryset())
 
     def get_queryset(self):
         """
         This is just here for legacy sake,
         some consumer subclasses have overriden this method
         """
-        return page_queryset(self.iterator)
+        try:
+            return self.queryset
+        except AttributeError as e:
+            raise WriterConfigException(
+                "Must define queryset attr, kwarg or override get_queryset()"
+            ) from e
 
     def get_column_configs(self):
-        model = self.iterator.model
+        model = self.get_queryset().model
 
         fields_to_write = model._meta.fields
         return [ModelColumn(model, field.name) for field in fields_to_write]
@@ -244,7 +262,7 @@ class AbstractCsvWriter(AbstractWriter):
             writer.writerow(csv_row)
 
 
-class ModelToCsvWriter(AbstractModelWriter, AbstractCsvWriter):
+class ModelToCsvWriter(AbstractCsvWriter, AbstractModelWriter):
     pass
 
 
@@ -289,7 +307,7 @@ class ModelToSheetWriter(AbstractSheetWriter, AbstractModelWriter):
         try:
             return super().get_sheet_name()
         except NotImplementedError:
-            return get_default_sheet_name_for_qs(self.iterator)
+            return get_default_sheet_name_for_qs(self.get_queryset())
 
 
 def serialize_value(value):
@@ -330,41 +348,60 @@ class BaseAbstractExportView(View):
 
     """
 
-    def get_iterator(self):
-        return self.get_queryset()
+    filename = None
+    sheetwriter_class = None
 
-    def get_queryset(self):
-        """
-        This is just here for legacy sake,
-        some consumer subclasses have overriden this method
-        """
-        try:
-            return self.queryset
-        except AttributeError as e:
+    def get_filename(self):
+        if not getattr(self, "filename", None):
             raise NotImplementedError(
-                "Must define queryset attr or override get_queryset()"
-            ) from e
+                "Must define filename attr or override get_filename()"
+            )
+
+    def _get_iterable(self):
+        if hasattr(self, "queryset"):
+            assert isinstance(self.queryset, QuerySet), "queryset must be a QuerySet"
+            return self.queryset
+        if hasattr(self, "iterator"):
+            return self.iterator
+
+        if hasattr(self, "get_queryset"):
+            qs = self.get_queryset()
+            assert isinstance(qs, QuerySet), "queryset must be a QuerySet"
+            return qs
+
+        if hasattr(self, "get_iterator"):
+            return self.get_iterator()
+
+        return None
 
     def get_sheetwriter_class(self):
-        try:
-            return self.sheetwriter_class
-        except AttributeError as e:
+        if not self.sheetwriter_class:
             raise NotImplementedError(
                 "Must define sheetwriter_class attr or override get_sheetwriter_class()"
-            ) from e
+            )
+        return self.sheetwriter_class
 
 
 class AbstractExportView(BaseAbstractExportView):
-    def get_filename(self):
-        return "export.xlsx"
+    filename = "export.xlsx"
 
     def get(self, request, *args, **kwargs):
         wb = openpyxl.Workbook(write_only=True)
         WriterCls = self.get_sheetwriter_class()
-        writer = WriterCls(
-            workbook=wb,
-            iterator=self.get_iterator(),
-        )
+
+        iterable = self._get_iterable()
+        if iterable is None:
+            writer = WriterCls(workbook=wb)
+        elif issubclass(WriterCls, AbstractModelWriter):
+            if not isinstance(iterable, QuerySet):
+                raise WriterConfigException("iterable must be a QuerySet")
+            writer = WriterCls(
+                workbook=wb,
+                queryset=iterable,
+            )
+        else:
+            writer = WriterCls(workbook=wb, iterator=iterable)
+
         writer.write()
         response = HttpResponse(headers={"Content-Type": "application/vnd.ms-excel"})
         response["Content-Disposition"] = f"attachment; filename={self.get_filename()}"
@@ -373,8 +410,7 @@ class AbstractExportView(BaseAbstractExportView):
 
 
 class AbstractCsvExportView(AbstractExportView):
-    def get_filename(self):
-        return "export.csv"
+    filename = "export.csv"
 
     def get_writer_class(self):
         try:
@@ -391,10 +427,21 @@ class AbstractCsvExportView(AbstractExportView):
                 "Content-Disposition": f"attachment; filename={self.get_filename()}"
             },
         )
+
         WriterCls = self.get_writer_class()
-        writer = WriterCls(
-            iterator=self.get_iterator(),
-            buffer=response,
-        )
+        iterable = self._get_iterable()
+        if iterable is None:
+            writer = WriterCls(buffer=response)
+
+        elif issubclass(WriterCls, AbstractModelWriter):
+            if not isinstance(iterable, QuerySet):
+                raise WriterConfigException("iterable must be a QuerySet")
+            writer = WriterCls(
+                queryset=iterable,
+                buffer=response,
+            )
+        else:
+            writer = WriterCls(buffer=response, iterator=iterable)
+
         writer.write()
         return response

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -212,7 +212,8 @@ class AbstractModelWriter(AbstractWriter):
     def __init__(self, **kwargs):
         if "iterator" in kwargs:
             raise WriterConfigException(
-                "don't use iterator kwarg, use the queryset kwarg, class attr or override get_queryset()"
+                "don't use iterator kwarg, use the queryset kwarg, "
+                "class attr or override get_queryset()"
             )
         if "queryset" in kwargs:
             self.queryset = kwargs.pop("queryset")
@@ -374,7 +375,7 @@ class BaseAbstractExportView(View):
 
         return None
 
-    def get_sheetwriter_class(self):
+    def get_sheetwriter_class(self) -> type:
         if not self.sheetwriter_class:
             raise NotImplementedError(
                 "Must define sheetwriter_class attr or override get_sheetwriter_class()"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ responses===0.23.3
 testfixtures===7.2.0
 flake8==6.1.0
 factory-boy===3.3.0
+coverage==7.1.0
+
 
 # publishing
 twine==4.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-phac_aspc-helpers
-version = 2.1.1
+version = "3.0.0rc1"
 description = Set of helpers for Django used at PHAC-ASPC
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Make writers (excel/csv/model) and their views declare configuration is a standard way, 

1. model-writers can't be instantiated with the iterator kwarg anymore, consumers must use the queryset arg
2. sheet-name, iterator and queryset can all be supplied via constructor kwarg, class property or method override, with a well defined precedence
3. Added a bunch of tests around this  