### PR TITLE
feat: Enable formats in excel exports

### DIFF
--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -338,7 +338,7 @@ class AbstractSheetWriter(AbstractWriter):
         To be overwritten by child classes when a style is to be applied to the
         header row.  If overwritten, should return a Style object.
         """
-        style = NamedStyle("default_style")
+        style = NamedStyle("empty_default_style")
         return style
 
     def get_column_widths(self):
@@ -375,7 +375,9 @@ class AbstractSheetWriter(AbstractWriter):
             for col in self.get_column_configs():
                 xl_val = col.get_serialized_value(record)
                 cell = WriteOnlyCell(worksheet, value=xl_val)
-                cell.style = col.get_style()
+                style = col.get_style()
+                if style:
+                    cell.style = style
                 xl_row.append(cell)
 
             worksheet.append(xl_row)

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -338,15 +338,7 @@ class AbstractSheetWriter(AbstractWriter):
         To be overwritten by child classes when a style is to be applied to the
         header row.  If overwritten, should return a Style object.
         """
-        style_name = "empty_default_style"
-
-        # Check if the style already exists
-        if style_name in self.workbook.named_styles:
-            style = self.workbook.named_styles[style_name]
-        else:
-            style = NamedStyle(name=style_name)
-
-        return style
+        return None
 
     def get_column_widths(self):
         """
@@ -363,6 +355,7 @@ class AbstractSheetWriter(AbstractWriter):
                 worksheet.column_dimensions[column_letter].width = column_width
 
         header_labels = self.get_header_row()
+        # pylint: disable=E1128
         header_style = self.get_header_style()
 
         header_row = []

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -338,7 +338,14 @@ class AbstractSheetWriter(AbstractWriter):
         To be overwritten by child classes when a style is to be applied to the
         header row.  If overwritten, should return a Style object.
         """
-        style = NamedStyle("empty_default_style")
+        style_name = "empty_default_style"
+
+        # Check if the style already exists
+        if style_name in self.workbook.named_styles:
+            style = self.workbook.named_styles[style_name]
+        else:
+            style = NamedStyle(name=style_name)
+
         return style
 
     def get_column_widths(self):

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -81,9 +81,6 @@ class Column:
     Base class to write columns in a sheet
     """
 
-    style = None
-    column_width = None
-
     def get_header(self):
         """return a header string for the column"""
         raise NotImplementedError()
@@ -114,8 +111,8 @@ class ModelColumn(Column):
     shorthand for defining a column that writes a scalar model field (non foreign-key)
     """
 
-    def __init__(self, model_cls, field_name, header_value=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, model_cls, field_name, header_value=None, **kwargs):
+        super().__init__(**kwargs)
         self.header_value = header_value
         self.model_cls = model_cls
         self.field_name = field_name
@@ -134,8 +131,8 @@ class ModelColumn(Column):
 
 
 class ChoiceColumn(Column):
-    def __init__(self, model_cls, field_name, header_value=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, model_cls, field_name, header_value=None, **kwargs):
+        super().__init__(**kwargs)
         self.header_value = header_value
         self.model_cls = model_cls
         self.field_name = field_name
@@ -154,8 +151,8 @@ class ChoiceColumn(Column):
 
 
 class CustomColumn(Column):
-    def __init__(self, header, get_val, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, header, get_val, **kwargs):
+        super().__init__(**kwargs)
         self.header = header
         self.get_val = get_val
 
@@ -175,10 +172,9 @@ class ManyToManyColumn(Column):
         get_related_str: callable = None,
         delimiter: str = ", ",
         header=None,
-        *args,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.model = model
         self.field_name = field_name
         self.header = header

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -11,7 +11,9 @@ from django.http import HttpResponse
 from django.utils.functional import Promise
 from django.utils.safestring import SafeString
 from openpyxl.cell import WriteOnlyCell
-
+from openpyxl.styles import (
+    NamedStyle,
+)
 
 from openpyxl.utils import get_column_letter
 
@@ -336,7 +338,8 @@ class AbstractSheetWriter(AbstractWriter):
         To be overwritten by child classes when a style is to be applied to the
         header row.  If overwritten, should return a Style object.
         """
-        return None
+        style = NamedStyle("default_style")
+        return style
 
     def get_column_widths(self):
         """
@@ -372,9 +375,7 @@ class AbstractSheetWriter(AbstractWriter):
             for col in self.get_column_configs():
                 xl_val = col.get_serialized_value(record)
                 cell = WriteOnlyCell(worksheet, value=xl_val)
-                style = col.get_style()
-                if style:
-                    cell.style = style
+                cell.style = col.get_style()
                 xl_row.append(cell)
 
             worksheet.append(xl_row)

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -11,9 +11,6 @@ from django.http import HttpResponse
 from django.utils.functional import Promise
 from django.utils.safestring import SafeString
 from openpyxl.cell import WriteOnlyCell
-from openpyxl.styles import (
-    NamedStyle,
-)
 
 from openpyxl.utils import get_column_letter
 

--- a/phac_aspc/django/excel.py
+++ b/phac_aspc/django/excel.py
@@ -80,6 +80,13 @@ class Column:
     Base class to write columns in a sheet
     """
 
+    style = None
+    column_width = None
+
+    def __init__(self, style=None, column_width=None):
+        self.style = style
+        self.column_width = column_width
+
     def get_header(self):
         """return a header string for the column"""
         raise NotImplementedError()
@@ -99,10 +106,6 @@ class Column:
 
     def get_column_width(self):
         return self.column_width
-
-    def __init__(self, style=None, column_width=None):
-        self.style = style
-        self.column_width = column_width
 
 
 class ModelColumn(Column):
@@ -313,6 +316,7 @@ class AbstractSheetWriter(AbstractWriter):
     # pylint: disable=W0223
 
     sheet_name = None
+    header_style = None
 
     def __init__(self, *args, workbook=None, sheet_name=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -335,7 +339,7 @@ class AbstractSheetWriter(AbstractWriter):
         To be overwritten by child classes when a style is to be applied to the
         header row.  If overwritten, should return a Style object.
         """
-        return None
+        return self.header_style
 
     def get_column_widths(self):
         """
@@ -347,7 +351,7 @@ class AbstractSheetWriter(AbstractWriter):
         worksheet = self.workbook.create_sheet(title=self.get_sheet_name())
 
         for col_index, column_width in enumerate(self.get_column_widths()):
-            if column_width:
+            if column_width is not None:
                 column_letter = get_column_letter(col_index + 1)
                 worksheet.column_dimensions[column_letter].width = column_width
 

--- a/phac_aspc/django/fields.py
+++ b/phac_aspc/django/fields.py
@@ -53,6 +53,7 @@ class DescriptionMixin:
         return name, path, args, kwargs
 
 
+# pylint: disable=abstract-method
 class ManyToManyField(DescriptionMixin, models.ManyToManyField):
     pass
 
@@ -106,6 +107,7 @@ class TextField(
         return name, path, args, kwargs
 
 
+# pylint: disable=abstract-method
 class ForeignKey(DescriptionMixin, models.ForeignKey):
     pass
 
@@ -153,6 +155,7 @@ class SlugField(DescriptionMixin, models.SlugField):
     pass
 
 
+# pylint: disable=abstract-method
 class OneToOneField(DescriptionMixin, models.OneToOneField):
     pass
 


### PR DESCRIPTION
- allows formatting of headers by overwritting the `get_header_style` method of the `ModelToSheetWriter` subclass.  
- allows formatting of columns and setting column widths by passing a style or column_width argument to any column class in `get_column_configs`.

@AlexCLeduc  This _should_ work, but I don't know how to actually test it to be sure...  